### PR TITLE
Convert argTypes to attributes

### DIFF
--- a/web/themes/custom/caesar/.storybook/plugins/caesar.js
+++ b/web/themes/custom/caesar/.storybook/plugins/caesar.js
@@ -5,7 +5,7 @@ import caesarSvgSpritePath from '../../images/sprite.svg';
 const argsDecoder = (setting, selected) => {
   if (setting.options) {
     if (typeof selected === 'object') {
-      return selected.map(value => findValueInObject(setting.options, value));
+      return selected.map((value) => findValueInObject(setting.options, value));
     }
     return findValueInObject(setting.options, selected);
   }
@@ -44,8 +44,7 @@ export const componentRender = (src, args) => {
       Object.entries(args[argName]).forEach(([attrName, attrValue]) => {
         if (attrName === 'class') {
           templateOptions[argName].addClass(attrValue);
-        }
-        else {
+        } else {
           templateOptions[argName].setAttribute(attrName, attrValue);
         }
       });
@@ -66,7 +65,6 @@ export const componentRender = (src, args) => {
 
   return refTemplate.render(templateOptions);
 };
-
 
 const findValueInObject = (obj, value) =>
   Object.keys(obj).find((key) => obj[key] === value);

--- a/web/themes/custom/caesar/.storybook/preview.js
+++ b/web/themes/custom/caesar/.storybook/preview.js
@@ -15,8 +15,14 @@ const allTwigPatternTemplates = import.meta.glob(
   { as: 'raw', import: 'default', eager: true },
 );
 
-import.meta.glob(['../libraries/**/*.css', '!../libraries/**/*.src.css'], { import: 'default', eager: true });
-const librariesJS = import.meta.glob(['../libraries/**/*.js', '!../libraries/**/*.src.js']);
+import.meta.glob(['../libraries/**/*.css', '!../libraries/**/*.src.css'], {
+  import: 'default',
+  eager: true,
+});
+const librariesJS = import.meta.glob([
+  '../libraries/**/*.js',
+  '!../libraries/**/*.src.js',
+]);
 for (const path in librariesJS) {
   librariesJS[path]();
 }
@@ -55,7 +61,6 @@ const breakpointsList = Object.keys(breakpoints).reduce(
   {},
 );
 
-
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
@@ -69,6 +74,29 @@ export const parameters = {
   uiPatterns,
   breakpointsList,
 };
+
+export const decorators = [
+  (story, context) => {
+    for (const argName of Object.keys(context.args)) {
+
+      // Converts argTypes prefixed with DRUPAL_ATTRIBUTE_ to drupal attributes args
+      if (argName.startsWith('DRUPAL_ATTRIBUTE_')) {
+        const name = argName.replace('DRUPAL_ATTRIBUTE_', '');
+        context.args.attributes[name] = context.args[argName];
+
+        // Also if drupal attribute is boolean and =false (disabled) remove it from attributes.
+        if (
+          context.argTypes[argName].control.type === 'boolean' &&
+          !context.args[argName]
+        ) {
+          delete context.args.attributes[name];
+        }
+      }
+    }
+
+    return story();
+  },
+];
 
 // Drupal + drupalSettings
 

--- a/web/themes/custom/caesar/templates/patterns/atoms/inputtext/a-inputtext.no_patterns.yml
+++ b/web/themes/custom/caesar/templates/patterns/atoms/inputtext/a-inputtext.no_patterns.yml
@@ -9,6 +9,11 @@ a_inputtext:
       description: Inputtext name (string)
       preview: 'Add'
   settings:
+    modifier:
+      type: checkboxes
+      label: Choose a modifier class
+      options:
+        a-inputtext--large: Large
     extra_classes:
       type: textfield
       label: Add extra CSS classes for atom inputtext separated by spaces.

--- a/web/themes/custom/caesar/templates/patterns/atoms/inputtext/a-inputtext.stories.js
+++ b/web/themes/custom/caesar/templates/patterns/atoms/inputtext/a-inputtext.stories.js
@@ -7,6 +7,26 @@ import './src/a-inputtext.pcss.css';
 export default {
   title: 'Atoms/Inputtext',
   ...storyGenerator(componentSource),
+  args: {
+    attributes: {
+      type: 'text',
+    },
+  },
 };
 
-export const Basic = {};
+export const Basic = {
+  argTypes: {
+    DRUPAL_ATTRIBUTE_disabled: {
+      name: 'Disabled',
+      type: 'boolean',
+    },
+    DRUPAL_ATTRIBUTE_required: {
+      name: 'Required',
+      type: 'boolean',
+    },
+    DRUPAL_ATTRIBUTE_maxlength: {
+      name: 'Max Length',
+      type: 'number',
+    },
+  },
+};

--- a/web/themes/custom/caesar/templates/patterns/atoms/inputtext/src/a-inputtext.pcss.css
+++ b/web/themes/custom/caesar/templates/patterns/atoms/inputtext/src/a-inputtext.pcss.css
@@ -1,3 +1,8 @@
 .a-inputtext {
   border: 1px solid black;
+  padding: 10px 20px;
+
+  &--large {
+    padding: 20px 40px;
+  }
 }


### PR DESCRIPTION
When we need to have custom controls on Drupal predefined args. like `type=inputtext` or `disabled` / `required` attributes
they should be forwarded to attributes  
